### PR TITLE
記事更新 update の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -15,6 +15,12 @@ module Api::V1
       render json: article
     end
 
+    def update
+      article = current_user.articles.find(params[:id])
+      article.update!(article_params)
+      render json: article
+    end
+
     private
 
       def article_params

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -71,3 +71,7 @@ RSpec/NestedGroups:
 # ブロックの方が見た目がスッキリして見やすいので、どちらでもお好きにどうぞ。
 RSpec/ReturnFromStub:
   Enabled: false
+
+# context ごとに let! を使い分けたい場合があるため無効に
+RSpec/LetSetup:
+  Enabled: false

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -73,4 +73,35 @@ RSpec.describe "Api::V1::Articles", type: :request do
       end
     end
   end
+
+  describe "PATCH /api/v1/articles/:id" do
+    subject { patch(api_v1_article_path(article.id), params: params) }
+
+    let(:params) { { article: attributes_for(:article) } }
+    let(:current_user) { create(:user) }
+    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+
+    context "自分の持っている記事のレコードを更新したとき" do
+      let(:article) { create(:article, user: current_user) }
+
+      it " 記事を更新できる" do
+        # 変化をチェックするには change マッチャーを使う
+        # 何から何に変わるかという書き方をする
+        # change { X }.from(A).to(B)
+        expect { subject }.to change { article.reload.title }.from(article.title).to(params[:article][:title]) &
+                              change { article.reload.body }.from(article.body).to(params[:article][:body])
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "自分が持っていない記事のレコードを更新しようとしたとき" do
+      let(:other_user) { create(:user) }
+      let!(:article) { create(:article, user: other_user) }
+
+      it "更新できない" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound) &
+                              change { Article.count }.by(0)
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -94,4 +94,6 @@ RSpec.configure do |config|
   config.define_derived_metadata do |meta|
     meta[:aggregate_failures] = true unless meta.has_key?(:aggregate_failures)
   end
+  # カスタムmatcher
+  RSpec::Matchers.define_negated_matcher :not_change, :change
 end


### PR DESCRIPTION
rubocop でDo not use let! to setup objects not referenced in tests の指摘を無効に